### PR TITLE
Fix potential trimming overflow

### DIFF
--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -27,8 +27,9 @@ std::string FormatMoney(const CAmount n)
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
-    for (int i = str.size()-1; (str[i] == '0' && IsDigit(str[i-2])); --i)
+    for (int i = str.size() - 1; i > 1 && str[i] == '0' && IsDigit(str[i - 2]); --i) {
         ++nTrim;
+    }
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);
 


### PR DESCRIPTION
## Summary
- guard `FormatMoney` against out-of-bounds access when trimming zeroes

## Testing
- `make -C src check TESTS=test/util_tests.cpp` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_6843932b443c832f8c0cac84eda9f60f